### PR TITLE
mikutter 3.1のEntityの仕様変更対応

### DIFF
--- a/.mikutter.yml
+++ b/.mikutter.yml
@@ -1,6 +1,6 @@
 slug: :mikutter_haiku
 depends:
-  mikutter: 3.0.4
+  mikutter: '3.1'
   plugin:
   - gtk
   - gui


### PR DESCRIPTION
今回の変更の主は、Twitterのエンティティを模したデータをMessageのコンストラクタに与えるという従来の方法から、新しく追加されたAPI Entity#add を呼び出すようにしたことです。

Entity#add は、今回のように独自のルールで動的にリンクをつける場合に使うAPIです（http://mikutter.blogspot.jp/2014/10/mikutter-3-1-pre.html の、MessageConverterを削除、Entity書き換え機能追加）。

上記記事では、エンティティをあとから書き換えられるということを強調していますが、こちらを使ったほうがコードが短くなるというメリットがあります。また、そういう理由から、若干内部構造が変わっていて、そのためmikutter_haikuの動作に影響を与えたと思われます。

実際の例はmikutter_haiku.rbの143行目あたり message.entity.add()というのを呼び出しているのがそれです。大幅に書き換えているように見えますが、先にMessageを作っておかなければいけないのでMessageの作成を前に持ってきて…とか処理の順番の入れ替えが大半です。
